### PR TITLE
Enforce HTTPS for CEDs

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,9 +1,29 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -33,13 +53,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
-};
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };

--- a/lib/CreateSoapClientWithWSDL.d.ts
+++ b/lib/CreateSoapClientWithWSDL.d.ts
@@ -1,1 +1,1 @@
-export default function CreateSoapClientWithWSDL(definition: string, uri: string): Promise<{}>;
+export default function CreateSoapClientWithWSDL(definition: string, uri: string): Promise<unknown>;

--- a/lib/CreateSoapClientWithWSDL.js
+++ b/lib/CreateSoapClientWithWSDL.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/Genius/definitions.js
+++ b/lib/Genius/definitions.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.CEDScreen = exports.CEDBoolean = exports.CEDItemTypes = exports.CEDCategories = exports.ExternalPaymentTypes = exports.EntryModes = exports.PaymentTypes = exports.TransactionTypes = void 0;
 var TransactionTypes;
 (function (TransactionTypes) {
     TransactionTypes["SALE"] = "SALE";

--- a/lib/Genius/index.js
+++ b/lib/Genius/index.js
@@ -11,10 +11,11 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -49,6 +50,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.impatientFetch = void 0;
 require("fetch-everywhere");
 var bluebird_1 = __importDefault(require("bluebird"));
 var GeniusWSDL_1 = __importDefault(require("./GeniusWSDL"));
@@ -117,7 +119,7 @@ var GeniusClient = /** @class */ (function () {
             return __generator(this, function (_a) {
                 params = { TransportKey: TransportKey, Format: "JSON" };
                 queryString = makeQueryString(params);
-                url = "http://" + this.config.CEDHostname + ":8080/v2/pos?" + queryString;
+                url = "https://" + this.config.CEDHostname + ":8443/v2/pos?" + queryString;
                 return [2 /*return*/, fetch(url)
                         .then(function (r) { return r.json(); })
                         .catch(function (e) { return e; })];
@@ -135,7 +137,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = { Action: "Status", Format: "JSON" };
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v2/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v2/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url, timeout)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -157,7 +159,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = { Action: "InitiateKeyedEntry", Format: "JSON" };
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -178,7 +180,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = { Action: "StartOrder", Format: "JSON", Order: Order };
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -205,7 +207,7 @@ var GeniusClient = /** @class */ (function () {
                             ExternalPaymentType: externalPaymentType
                         };
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -226,7 +228,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = { Action: "Cancel", Format: "JSON" };
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url, timeout)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -247,7 +249,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "AddItem", Format: "JSON" }, item);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -268,7 +270,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "DiscountItem", Format: "JSON" }, discountItem);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -289,7 +291,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "DeleteItem", Format: "JSON" }, item);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -310,7 +312,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "DeleteAllItems", Format: "JSON" }, deleteParams);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -331,7 +333,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "UpdateItem", Format: "JSON" }, item);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];
@@ -348,7 +350,7 @@ var GeniusClient = /** @class */ (function () {
                     case 0:
                         params = __assign({ Action: "UpdateTotal", Format: "JSON" }, updateParams);
                         queryString = makeQueryString(params);
-                        url = "http://" + this.config.CEDHostname + ":8080/v1/pos?" + queryString;
+                        url = "https://" + this.config.CEDHostname + ":8443/v1/pos?" + queryString;
                         return [4 /*yield*/, impatientFetch(url)
                                 .then(function (r) { return r.json(); })
                                 .catch(function (e) { return e; })];

--- a/lib/Merchantware/Credit/definitions.js
+++ b/lib/Merchantware/Credit/definitions.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TaxIndicator = exports.CardType = exports.ReaderEntryMode = void 0;
 var ReaderEntryMode;
 (function (ReaderEntryMode) {
     ReaderEntryMode["Unknown"] = "0";

--- a/lib/Merchantware/Credit/index.js
+++ b/lib/Merchantware/Credit/index.js
@@ -11,10 +11,11 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.MerchantwareCreditClient = exports.GeniusClient = void 0;
 var Genius_1 = __importDefault(require("./Genius"));
 exports.GeniusClient = Genius_1.default;
 var Credit_1 = __importDefault(require("./Merchantware/Credit"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayan",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Javascript library for Cayan API's",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Genius/index.ts
+++ b/src/Genius/index.ts
@@ -85,7 +85,7 @@ export default class GeniusClient {
   ): Promise<IInitiateTransactionResult | Error> {
     const params = { TransportKey, Format: "JSON" };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v2/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v2/pos?${queryString}`;
 
     return fetch(url)
       .then(r => r.json())
@@ -98,7 +98,7 @@ export default class GeniusClient {
   async CheckStatus(timeout?: number): Promise<ICheckStatusResponse | Error> {
     const params = { Action: "Status", Format: "JSON" };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v2/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v2/pos?${queryString}`;
     return await impatientFetch(url, timeout)
       .then(r => r.json())
       .catch(e => e);
@@ -113,7 +113,7 @@ export default class GeniusClient {
   ): Promise<IStartOrderResponse | Error> {
     const params = { Action: "InitiateKeyedEntry", Format: "JSON" };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -126,7 +126,7 @@ export default class GeniusClient {
   async StartOrder(Order: string): Promise<IStartOrderResponse | Error> {
     const params = { Action: "StartOrder", Format: "JSON", Order };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -148,7 +148,7 @@ export default class GeniusClient {
       ExternalPaymentType: externalPaymentType
     };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -162,7 +162,7 @@ export default class GeniusClient {
   ): Promise<ICancelTransactionResponse | Error> {
     const params = { Action: "Cancel", Format: "JSON" };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url, timeout)
       .then(r => r.json())
       .catch(e => e);
@@ -175,7 +175,7 @@ export default class GeniusClient {
   async AddItem(item: IAddItemParameters): Promise<IAddItemResponse | Error> {
     const params = { Action: "AddItem", Format: "JSON", ...item };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -190,7 +190,7 @@ export default class GeniusClient {
   ): Promise<IDiscountItemResponse | Error> {
     const params = { Action: "DiscountItem", Format: "JSON", ...discountItem };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -205,7 +205,7 @@ export default class GeniusClient {
   ): Promise<IDeleteItemResponse | Error> {
     const params = { Action: "DeleteItem", Format: "JSON", ...item };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -224,7 +224,7 @@ export default class GeniusClient {
       ...deleteParams
     };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -239,7 +239,7 @@ export default class GeniusClient {
   ): Promise<IUpdateItemResponse | Error> {
     const params = { Action: "UpdateItem", Format: "JSON", ...item };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);
@@ -250,7 +250,7 @@ export default class GeniusClient {
   ): Promise<IUpdateTotalResponse | Error> {
     const params = { Action: "UpdateTotal", Format: "JSON", ...updateParams };
     const queryString = makeQueryString(params);
-    const url = `http://${this.config.CEDHostname}:8080/v1/pos?${queryString}`;
+    const url = `https://${this.config.CEDHostname}:8443/v1/pos?${queryString}`;
     return await impatientFetch(url)
       .then(r => r.json())
       .catch(e => e);

--- a/test/genius_client.ts
+++ b/test/genius_client.ts
@@ -20,7 +20,7 @@ describe("GeniusClient", () => {
   };
   let client: GeniusClient;
   // const genius = new GeniusClient(config);
-  const CEDUrl = `http://${config.CEDHostname}:8080`;
+  const CEDUrl = `https://${config.CEDHostname}:8443`;
 
   before(async () => {
     client = await GeniusClient.createInstance(config);


### PR DESCRIPTION
This PR changes the default CED url from `http` (port 8080) to `https` (port 8443).

The `http` protocol usage works great during development and `localhost` but, once deployed, browsers will throw exceptions for using an insecure protocol. In Chrome specifically, a `Mixed content` exception is thrown and the request is blocked.

The fix is to ensure the `https` protocol is used. For the certificate, the [Cayan CA](https://docs.tsysmerchant.com/knowledge-base/faqs/how-do-i-install-the-genius-root-certificate) can be installed when using the IP of the CED (currently not working in macOS), or simply using the Hostname of the CED works out-of-the-box.